### PR TITLE
Remote Api body serialization fails when using curl

### DIFF
--- a/src/javasource/unittesting/RemoteApiServlet.java
+++ b/src/javasource/unittesting/RemoteApiServlet.java
@@ -2,12 +2,12 @@ package unittesting;
 
 import java.io.IOException;
 
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.auth.InvalidCredentialsException;
-import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -22,6 +22,7 @@ import com.mendix.logging.ILogNode;
 import com.mendix.m2ee.api.IMxRuntimeRequest;
 import com.mendix.m2ee.api.IMxRuntimeResponse;
 import com.mendix.systemwideinterfaces.core.IContext;
+
 import communitycommons.XPath;
 
 public class RemoteApiServlet extends RequestHandler {
@@ -134,8 +135,18 @@ public class RemoteApiServlet extends RequestHandler {
 	}
 
 	private JSONObject parseInput(HttpServletRequest request) throws IOException {
-		String data = IOUtils.toString(request.getInputStream());
-		return new JSONObject(data);
+		final ServletInputStream is = request.getInputStream();
+
+		final StringBuilder sb = new StringBuilder();
+
+		int next = is.read();
+		while (next != -1) {
+			final char c = (char) next;
+			sb.append(c);
+			next = is.read();
+		}
+
+		return new JSONObject(sb.toString());
 	}
 
 	private class TestSuiteRunner {


### PR DESCRIPTION
`IOUtils.toString()` does not deserialize body content sent with curl, so do it manually.

* It did already and still does work when using postman in chrome.
* Tested on Windows 8.1 64-bit with `curl 7.30.0 (i386-pc-win32) libcurl/7.30.0 OpenSSL/0.9.8y zlib/1.2.7`

I am unsure whether this can be solved by e.g. using a different encoding, because in both cases the input stream contained 18 bytes for `{"password" : "1"}` (might have been with or without extra spaces, though).

Suggestions for a better solution?