### PR TITLE
Restart transaction when test fails

### DIFF
--- a/src/javasource/unittesting/TestManager.java
+++ b/src/javasource/unittesting/TestManager.java
@@ -355,6 +355,8 @@ public class TestManager
 			return res;
 		}
 		catch(Exception e) {
+			if (testSuite.getAutoRollbackMFs())
+				mfContext.startTransaction();
 			start = System.currentTimeMillis() - start;
 			test.setResult(UnitTestResult._2_Failed);
 			Throwable cause = ExceptionUtils.getRootCause(e);
@@ -368,7 +370,6 @@ public class TestManager
 		finally {
 			if (testSuite.getAutoRollbackMFs())
 				mfContext.rollbackTransAction();
-				
 			test.setLastStep(lastStep);
 			test.setReadableTime((start > 10000 ? Math.round(start / 1000) + " seconds" : start + " milliseconds"));
 			commitSilent(test);

--- a/src/javasource/unittesting/UnitTestRunListener.java
+++ b/src/javasource/unittesting/UnitTestRunListener.java
@@ -4,7 +4,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.security.AccessControlException;
 import java.util.Date;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;


### PR DESCRIPTION
When one test failed, the next unit test was not running in the setup transaction anymore. A new transaction is now started when in case a test fails.