### PR TITLE
Fix for the null pointer exception during tear down

### DIFF
--- a/src/javasource/unittesting/TestManager.java
+++ b/src/javasource/unittesting/TestManager.java
@@ -144,22 +144,18 @@ public class TestManager
 
 	private void runMfTearDown(TestSuite testSuite) 
 	{
-		IContext tearDownContext = null;
+		IContext tearDownContext = setupContext;
 		if (Core.getMicroflowNames().contains(testSuite.getModule() + ".TearDown")) {
 			try
 			{
 				LOG.info("Running TearDown microflow..");
-				if (testSuite.getAutoRollbackMFs()) {
-					if (Core.getMicroflowNames().contains(testSuite.getModule() + ".Setup")) {
-						tearDownContext = setupContext;
-					} else {
-						tearDownContext = Core.createSystemContext();
-						tearDownContext.startTransaction();
-					}
-					Core.execute(tearDownContext, testSuite.getModule() + ".TearDown", emptyArguments);
-				} else {
-					Core.execute(Core.createSystemContext(), testSuite.getModule() + ".TearDown", emptyArguments);
+				if (!Core.getMicroflowNames().contains(testSuite.getModule() + ".Setup")) {
+					tearDownContext = Core.createSystemContext();
 				}
+				if (testSuite.getAutoRollbackMFs()) {
+					tearDownContext.startTransaction();
+				}
+				Core.execute(tearDownContext, testSuite.getModule() + ".TearDown", emptyArguments);
 			}
 			catch (Exception e)
 			{
@@ -168,9 +164,13 @@ public class TestManager
 			}
 		}
 		
-		if (testSuite.getAutoRollbackMFs()) {
+		// Either we had a teardown a teardown or 
+		if (testSuite.getAutoRollbackMFs() && tearDownContext != null) {
 			tearDownContext.rollbackTransAction();
 		}
+		
+		// Make sure we clean setupContext after running this test/suite
+		setupContext = null;
 	}
 	
 	public synchronized void runTestSuites() throws CoreException {

--- a/src/javasource/unittesting/TestManager.java
+++ b/src/javasource/unittesting/TestManager.java
@@ -149,7 +149,7 @@ public class TestManager
 			try
 			{
 				LOG.info("Running TearDown microflow..");
-				if (!Core.getMicroflowNames().contains(testSuite.getModule() + ".Setup")) {
+				if (tearDownContext == null) {
 					tearDownContext = Core.createSystemContext();
 				}
 				if (testSuite.getAutoRollbackMFs()) {


### PR DESCRIPTION
This was accidentally added in the previous PR.

In order to avoid future problems, I also added three extra test suites:
- With Setup only
- With Tear down only
- With both Setup and Tear down
(The existing test already tests for the lack of both setup and tear down.)

There's also a small page for each of these test suites to keep track that the data was correctly rolled back (in case it was selected) without having to open a db viewer.

As a last measure, I also make sure that the last step during tear down is to set the setupContext to null, in an attempt to isolate test runs from each other.