### PR TITLE
Decreased the sleep timers for JUnit tests

### DIFF
--- a/src/javasource/unittesting/UnittestingUnitTest1.java
+++ b/src/javasource/unittesting/UnittestingUnitTest1.java
@@ -12,14 +12,14 @@ public class UnittestingUnitTest1
 	@Before
 	public void setup() throws InterruptedException {
 		this.state = false;
-		Thread.sleep(1000);
+		Thread.sleep(10);
 	}
 	
 	@Test
-	public void testOfOneSecondSetupAndOneSecundRun() throws InterruptedException {
+	public void testOfOneMsSecondSetupAndOneMsSecundRun() throws InterruptedException {
 		this.state = true;
 		TestManager.instance().reportStep("Sleeping a while");
-		Thread.sleep(1000);
+		Thread.sleep(10);
 		TestManager.instance().reportStep("Sleeping done!");
 		assertTrue(state);
 	}

--- a/src/javasource/unittesting/UnittestingUnitTest2.java
+++ b/src/javasource/unittesting/UnittestingUnitTest2.java
@@ -11,12 +11,12 @@ public class UnittestingUnitTest2 extends AbstractUnitTest
 	
 	@Before
 	public void setup() throws InterruptedException {
-		Thread.sleep(500);
+		Thread.sleep(5);
 	}
 	
 	@After
 	public void tearDown() throws InterruptedException {
-		Thread.sleep(500);
+		Thread.sleep(5);
 	}
 	
 	@Test
@@ -24,7 +24,7 @@ public class UnittestingUnitTest2 extends AbstractUnitTest
 		this.startTimeMeasure();
 		
 		this.reportStep("By inheriting from AbstractUnitTest some utility methods are provided and time can be tracted in a more reliable way (without counting setup and teardown)");
-		Thread.sleep(1000);
+		Thread.sleep(10);
 		
 		assertTrue(true);
 		


### PR DESCRIPTION
I noticed my unit tests took quite a bit longer when I had the FindJUnitTests enabled. Investigating further, I noticed there were several Thread.sleep() functions built in. In total, they take 4 seconds. Is there any specific reason for this? 
If you want to perform the Unit Tests in an after startup, each startup takes 4 seconds longer, which is annoying.